### PR TITLE
fix: point legacy migration directly to beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Point the standalone 1.x migration assistant directly to the now-published `2.0.0-beta.3` release.
+
 ## 2.0.0-beta.3 - 2026-08-21
 
 - Replace the legacy raw-script entry with a standalone 1.x-to-2.x reinstallation assistant that downloads and verifies a complete release package without changing existing VPS configuration.

--- a/tests/unit/test_legacy_migration.sh
+++ b/tests/unit/test_legacy_migration.sh
@@ -9,8 +9,8 @@ PROJECT_ROOT=$(cd -- "$TEST_DIR/../.." && pwd)
 source "$PROJECT_ROOT/tests/test_helper.sh"
 
 actual=$("$PROJECT_ROOT/vps_secure.sh" --version)
-assert_contains "$actual" 'legacy migration v1.0.2' "legacy raw entry is a migration assistant"
-assert_contains "$actual" '2.0.0-beta.2.1' "legacy migration points to a complete published package"
+assert_contains "$actual" 'legacy migration v1.0.3' "legacy raw entry is a migration assistant"
+assert_contains "$actual" '2.0.0-beta.3' "legacy migration points directly to the current published package"
 
 actual=$(printf '0\n' | "$PROJECT_ROOT/vps_secure.sh")
 assert_contains "$actual" '1.x 单文件版本已经停止功能更新' "legacy users receive an end-of-maintenance notice"
@@ -19,9 +19,9 @@ assert_contains "$actual" '不会' "migration notice explains preserved server c
 temporary_root=$(mktemp -d)
 fixture_root="$temporary_root/fixture"
 fake_bin="$temporary_root/bin"
-archive_name='vps-secure-platform-2.0.0-beta.2.1.tar.gz'
+archive_name='vps-secure-platform-2.0.0-beta.3.tar.gz'
 mkdir -p "$fixture_root" "$fake_bin"
-printf '%s\n' '2.0.0-beta.2.1' > "$fixture_root/VERSION"
+printf '%s\n' '2.0.0-beta.3' > "$fixture_root/VERSION"
 cat > "$fixture_root/install.sh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' installed > "$VPS_MIGRATION_TEST_MARKER"

--- a/vps_secure.sh
+++ b/vps_secure.sh
@@ -4,9 +4,9 @@ set -u
 
 # Keep this assignment simple: VPS Secure 1.x extracts it from the raw file to
 # discover that a replacement is available.
-VERSION_TAG="v1.0.2"
+VERSION_TAG="v1.0.3"
 
-MIGRATION_TARGET_VERSION=${VPS_MIGRATION_TARGET_VERSION:-2.0.0-beta.2.1}
+MIGRATION_TARGET_VERSION=${VPS_MIGRATION_TARGET_VERSION:-2.0.0-beta.3}
 MIGRATION_REPOSITORY=${VPS_MIGRATION_REPOSITORY:-playfulsoul/vps-secure-script}
 MIGRATION_RELEASE_BASE=${VPS_MIGRATION_RELEASE_BASE:-https://github.com/$MIGRATION_REPOSITORY/releases/download/v$MIGRATION_TARGET_VERSION}
 MIGRATION_LINK_PATH=${VPS_MIGRATION_LINK_PATH:-/usr/local/bin/vps}


### PR DESCRIPTION
## Summary

- update the standalone 1.x migration assistant from v1.0.2 to v1.0.3
- point new 1.x migrations directly to the published 2.0.0-beta.3 release
- update migration tests and record the post-release adjustment

## Why

Before beta.3 was published, the migration bridge deliberately targeted the last complete public package, beta.2.1, to avoid a temporary missing-download window. Beta.3 is now public, so new 1.x migrations can install it in one verified step instead of installing beta.2.1 first.

## Validation

- full local test suite and ShellCheck passed
- GitHub CI passed for commit 9c2eecc
- the default public beta.3 archive and SHA-256 URLs were downloaded and verified without executing the installer

This does not modify the existing beta.3 tag or Release assets.