### PR TITLE
docs: validate Debian 13 installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Point the standalone 1.x migration assistant directly to the published `2.0.0-beta.4` release.
 - Add public testing and release guides, contribution/security/support policies, and structured GitHub issue and pull-request templates.
+- Make the beta installation instructions work on minimal Debian/Ubuntu images without preinstalled curl and stop the command chain after the first failed step.
+- Record successful Debian 13 validation for SSH port preservation, UFW, Fail2Ban, rollback, recovery, and reboot persistence.
 
 ## 2.0.0-beta.4 - 2026-08-21
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -12,7 +12,7 @@
 
 | Platform | Level | Notes |
 | --- | --- | --- |
-| Debian 13 | Target | systemd journal-aware Fail2Ban configuration; manual validation pending |
+| Debian 13 | Compatible | fresh minimal installation prerequisites; default and custom SSH ports; initially inactive UFW; journald Fail2Ban; repeated apply, rollback, recovery, and reboot persistence manually validated |
 | Debian 12 | Compatible | default, dual, and custom-only SSH ports; active and initially inactive UFW; journald Fail2Ban; reboot persistence; verification and rollback manually validated; remaining scenarios documented separately |
 | Debian 11 | Target | security fixes only after capability detection; manual validation pending |
 | Debian 10 | Unsupported target for 2.x | immutable legacy source remains for reference; migration assistant must stop before unsupported installation |
@@ -44,4 +44,4 @@ High-risk modules are not marked supported until these scenarios pass where appl
 
 Recognizing `/etc/os-release` is not sufficient. A supported platform must have tested adapters, safe failure behavior, post-change verification, and documented recovery steps.
 
-Current manual validation records are available for [Debian 12](docs/DEBIAN_12_VALIDATION.md), [Ubuntu 22.04](docs/UBUNTU_22_04_VALIDATION.md), and [Ubuntu 24.04](docs/UBUNTU_24_04_VALIDATION.md).
+Current manual validation records are available for [Debian 12](docs/DEBIAN_12_VALIDATION.md), [Debian 13](docs/DEBIAN_13_VALIDATION.md), [Ubuntu 22.04](docs/UBUNTU_22_04_VALIDATION.md), and [Ubuntu 24.04](docs/UBUNTU_24_04_VALIDATION.md).

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 
 当前开发版本为 `2.0.0-beta.4`。它保留了 1.x 简单直观的彩色分区菜单，同时使用 2.x 模块化安全内核：执行前说明变化、保留当前 SSH 端口、执行后自动验证，并为关键操作保存回滚点。
 
-> Beta 版本已经在 Debian 12、Ubuntu 22.04 和 Ubuntu 24.04 的真实 VPS 上完成主要安全流程测试。首次使用仍建议选择有网页控制台、快照或救援模式的测试机。
+> Beta 版本已经在 Debian 12、Debian 13、Ubuntu 22.04 和 Ubuntu 24.04 的真实 VPS 上完成主要安全流程测试。首次使用仍建议选择有网页控制台、快照或救援模式的测试机。
 
 ## 安装后怎样使用
 
-输入：
+如果当前提示符以 `root@` 开头，直接输入：
 
 ```bash
-sudo vps
+vps
 ```
+
+普通 sudo 用户输入 `sudo vps`。
 
 程序会显示服务器状态和中文菜单：
 
@@ -60,16 +62,37 @@ SSH 防暴力破解：运行正常
 
 ## 安装 beta 版本
 
-从 GitHub Release 下载程序包和校验文件，验证无误后安装：
+全新的 Debian/Ubuntu 最小化系统可能没有预装 `curl`。如果命令提示
+`curl: command not found`，先安装下载工具和 HTTPS 证书：
 
 ```bash
-curl -fLO https://github.com/playfulsoul/vps-secure-script/releases/download/v2.0.0-beta.4/vps-secure-platform-2.0.0-beta.4.tar.gz
-curl -fLO https://github.com/playfulsoul/vps-secure-script/releases/download/v2.0.0-beta.4/vps-secure-platform-2.0.0-beta.4.tar.gz.sha256
-sha256sum -c vps-secure-platform-2.0.0-beta.4.tar.gz.sha256
-tar -xzf vps-secure-platform-2.0.0-beta.4.tar.gz
-sudo ./install.sh
-sudo vps
+apt-get update
+apt-get install -y ca-certificates curl
 ```
+
+上面两条命令适用于提示符以 `root@` 开头的 root 用户。普通 sudo 用户请在
+`apt-get` 前加上 `sudo`。
+
+然后从 GitHub Release 下载程序包和校验文件。以下命令使用 `&&` 串联，任意一步
+失败都会停止，不会在缺少安装包时继续执行解压或安装：
+
+```bash
+mkdir -p ~/vps-secure-install &&
+cd ~/vps-secure-install &&
+curl -fLO https://github.com/playfulsoul/vps-secure-script/releases/download/v2.0.0-beta.4/vps-secure-platform-2.0.0-beta.4.tar.gz &&
+curl -fLO https://github.com/playfulsoul/vps-secure-script/releases/download/v2.0.0-beta.4/vps-secure-platform-2.0.0-beta.4.tar.gz.sha256 &&
+sha256sum -c vps-secure-platform-2.0.0-beta.4.tar.gz.sha256 &&
+tar -xzf vps-secure-platform-2.0.0-beta.4.tar.gz &&
+./install.sh &&
+vps
+```
+
+普通 sudo 用户应把最后两条命令改为 `sudo ./install.sh` 和 `sudo vps`。
+校验成功时会显示 `vps-secure-platform-2.0.0-beta.4.tar.gz: OK`。
+
+如果出现 `sudo: unable to resolve host`，这是 VPS 模板中的 `/etc/hostname` 与
+`/etc/hosts` 不一致，不是安装包下载失败。root 用户可以暂时不使用 `sudo`，并在
+修改主机名配置前先执行 `hostname`、`cat /etc/hostname` 和 `cat /etc/hosts` 核对。
 
 安装和防火墙操作期间请保持当前 SSH 窗口打开。有条件时先创建 VPS 快照，并确认服务商网页控制台可用。
 
@@ -109,7 +132,7 @@ Get-Content $env:USERPROFILE\.ssh\id_ed25519.pub
 
 ### 第三步：在 VPS 中导入
 
-运行 `sudo vps`，依次选择：
+root 用户运行 `vps`（普通 sudo 用户运行 `sudo vps`），依次选择：
 
 ```text
 2. 安全防护
@@ -221,6 +244,7 @@ sudo vps module install https://example.org/example-module.tar.gz \
 真实 VPS 验收记录：
 
 - [Debian 12](docs/DEBIAN_12_VALIDATION.md)
+- [Debian 13](docs/DEBIAN_13_VALIDATION.md)
 - [Ubuntu 22.04](docs/UBUNTU_22_04_VALIDATION.md)
 - [Ubuntu 24.04](docs/UBUNTU_24_04_VALIDATION.md)
 

--- a/docs/DEBIAN_13_VALIDATION.md
+++ b/docs/DEBIAN_13_VALIDATION.md
@@ -1,0 +1,99 @@
+# Debian 13 Validation Record
+
+## Scope
+
+This record summarizes a manual integration run completed on 2026-08-22 with the
+published `2.0.0-beta.4` release. Host, client, and hostile-source addresses are
+intentionally omitted.
+
+The target was a fresh minimal Debian 13 installation using systemd,
+`ssh.service`, OpenSSH on port 22, UFW, and Fail2Ban with the systemd journal
+backend. The host started on a 6.12.38 kernel and booted into the installed
+6.12.101 kernel during the persistence test.
+
+The minimal image did not include curl. The original copied installation block
+therefore failed at its first download and continued into misleading checksum,
+extraction, and installation errors. After `ca-certificates` and `curl` were
+installed through APT, the published archive installation completed and the
+global `vps` command opened normally. This exposed an installation-documentation
+gap rather than a Debian 13 runtime incompatibility.
+
+The provider image also had a hostname that did not match `/etc/hosts`, causing
+sudo to print an `unable to resolve host` warning. Correcting the local hostname
+mapping removed the warning. The warning did not cause the release download
+failure.
+
+## Verified workflows
+
+### Platform and SSH
+
+- Detected Debian 13, APT, systemd, `ssh.service`, and the current port 22 SSH
+  session.
+- Confirmed that the doctor, SSH status, firewall plan, and Fail2Ban plan retained
+  the existing SSH port without falling back to 22 as an invented default.
+- Added a temporary OpenSSH drop-in selecting port 32876 and confirmed that the
+  platform detected the transition ports before restarting SSH.
+- Applied the firewall before restarting SSH, confirmed that OpenSSH listened on
+  port 32876, and established a real new external SSH connection through that
+  port.
+- Removed the temporary drop-in, restarted SSH, restored the Termius host to port
+  22, and established a real new port 22 connection.
+
+### UFW
+
+- Confirmed an active firewall with only the expected port 22 IPv4 and IPv6
+  rules.
+- Repeated a healthy apply and confirmed that it did not duplicate rules or
+  replace the existing meaningful rollback point.
+- Rolled the module back to the pre-application inactive state.
+- Reapplied the module and confirmed that it added only the confirmed SSH port
+  before enabling UFW.
+- Added port 32876 during the live SSH transition, verified it from the new
+  external session, then rolled back only that temporary rule after returning to
+  port 22.
+
+### Fail2Ban
+
+- Confirmed that the installed service responded to `fail2ban-client ping` and
+  that the live sshd jail was detecting failed logins and banning hostile
+  sources.
+- Repeated a healthy apply without restarting the service or replacing the
+  meaningful rollback point.
+- Rolled back the module-owned configuration while retaining the package-managed
+  enabled and active service state.
+- Ran the non-mutating merged-configuration preflight successfully.
+- Reapplied and verified the systemd journal backend on port 22 and during the
+  `22,32876` transition, then restored the final port 22 configuration.
+- Confirmed that `/etc/fail2ban/jail.local` was absent and that the platform used
+  only `/etc/fail2ban/jail.d/90-vps-secure.local`.
+
+### Reboot persistence
+
+- Confirmed before reboot that SSH, UFW, and Fail2Ban were enabled.
+- Rebooted the VPS and established a fresh Termius connection on port 22.
+- Confirmed that `ssh.service`, `ufw.service`, and `fail2ban.service` were active
+  after boot.
+- Confirmed that UFW retained only the expected port 22 rules and that Fail2Ban
+  responded to its client.
+- Re-ran firewall verification, Fail2Ban verification, and `vps doctor`; all
+  passed.
+
+## Final state
+
+- OpenSSH listens on port 22 and accepts new external sessions.
+- UFW is enabled and active with only the expected port 22 IPv4 and IPv6 rules.
+- Fail2Ban is enabled, active, and protects port 22 through the systemd backend.
+- No temporary OpenSSH drop-in or port 32876 firewall rule remains in active
+  configuration.
+- The global `vps` command is installed and the doctor reports no blocking issue.
+
+## Remaining validation gaps
+
+- a custom port placed directly in the main `sshd_config` rather than a drop-in;
+- systemd SSH socket activation, which is covered by the Ubuntu 24.04 record;
+- an explicitly selected file-log Fail2Ban backend;
+- APT/dpkg lock contention and interrupted-operation fault injection;
+- hosts with complex pre-existing UFW or nftables policy.
+
+Debian 13 is therefore classified as compatible and manually validated for the
+workflows above, not fully supported under the complete compatibility policy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 ## 实机验证记录
 
 - [Debian 12](DEBIAN_12_VALIDATION.md)
+- [Debian 13](DEBIAN_13_VALIDATION.md)
 - [Ubuntu 22.04](UBUNTU_22_04_VALIDATION.md)
 - [Ubuntu 24.04](UBUNTU_24_04_VALIDATION.md)
 - [Debian/Ubuntu 测试计划](DEBIAN_TEST_PLAN.md)

--- a/tests/unit/test_project_baseline.sh
+++ b/tests/unit/test_project_baseline.sh
@@ -13,6 +13,7 @@ assert_file_exists "$PROJECT_ROOT/MODULE_SPEC.md" "module contract is documented
 assert_file_exists "$PROJECT_ROOT/COMPATIBILITY.md" "compatibility policy is documented"
 assert_file_exists "$PROJECT_ROOT/docs/TESTING.md" "testing policy is documented"
 assert_file_exists "$PROJECT_ROOT/docs/RELEASE_PROCESS.md" "release process is documented"
+assert_file_exists "$PROJECT_ROOT/docs/DEBIAN_13_VALIDATION.md" "Debian 13 validation is documented"
 assert_file_exists "$PROJECT_ROOT/CONTRIBUTING.md" "contribution policy is documented"
 assert_file_exists "$PROJECT_ROOT/CODE_OF_CONDUCT.md" "community conduct policy is documented"
 assert_file_exists "$PROJECT_ROOT/SECURITY.md" "security reporting policy is documented"
@@ -22,6 +23,12 @@ assert_file_exists "$PROJECT_ROOT/legacy/v1.0.1/vps_secure.sh" "legacy script is
 release_process=$(<"$PROJECT_ROOT/docs/RELEASE_PROCESS.md")
 assert_contains "$release_process" 'Release 已公开并通过下载验证后' \
     "release process defers the legacy migration pointer until publication"
+
+readme=$(<"$PROJECT_ROOT/README.md")
+assert_contains "$readme" 'apt-get install -y ca-certificates curl' \
+    "minimal Debian and Ubuntu installation documents curl prerequisites"
+assert_contains "$readme" 'curl: command not found' \
+    "installation guide explains the minimal-image curl failure"
 
 actual_checksum=$(shasum -a 256 "$PROJECT_ROOT/legacy/v1.0.1/vps_secure.sh" | awk '{print $1}')
 if [[ "$actual_checksum" == 'b48125bb46036baa82dce22725e62ff67a3377e1bad6efe28a87b3718049d4a0' ]]; then


### PR DESCRIPTION
## Summary

- document curl and CA prerequisites for fresh minimal Debian/Ubuntu images
- stop the copied installation workflow after the first failed step
- clarify root versus sudo usage and the unrelated hostname-resolution warning
- add a redacted Debian 13 live validation record and classify Debian 13 as compatible

## Validation

- complete local test suite and ShellCheck passed
- verified UFW and Fail2Ban apply, repeated apply, rollback, recovery, and reboot persistence on a fresh Debian 13 VPS
- established real external SSH sessions on temporary port 32876 and restored port 22
- confirmed the final host retains only the expected port 22 firewall and Fail2Ban configuration
- public-content privacy audit passed